### PR TITLE
fixed mixin forms

### DIFF
--- a/src/pug/mixins/_forms.pug
+++ b/src/pug/mixins/_forms.pug
@@ -4,5 +4,8 @@ mixin test-form(title, type, name, placeholder)
 
 mixin textarea(label, text)
 	.mb-15
-		.title-medium.pb-15 #{label}
-		textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30'  name='message') #{text}
+		if label
+			.title-medium.pb-15 #{label}
+			textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30'  name='message') #{text}
+		else
+			textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30'  name='message') #{text}

--- a/src/pug/mixins/_forms.pug
+++ b/src/pug/mixins/_forms.pug
@@ -2,10 +2,9 @@ mixin test-form(title, type, name, placeholder)
 		.title-medium #{title}
 		input(type = type, name = name, placeholder = placeholder).input.pl-15.mb-15
 
-mixin textarea(label, text)
-	.mb-15
-		if label
-			.title-medium.pb-15 #{label}
-			textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30'  name='message') #{text}
-		else
-			textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30'  name='message') #{text}
+mixin textarea(name, placeholder, label)
+	if label
+		.title-medium.pb-15 #{label}
+		textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30',  name= name, placeholder= placeholder)
+	else
+		textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30',  name= name, placeholder= placeholder)

--- a/src/pug/pages/ui/comment-add.pug
+++ b/src/pug/pages/ui/comment-add.pug
@@ -10,3 +10,6 @@ block content
 	.main-wrapper
 		.container.container--left
 			.title.mb-0 Комментарии
+
+			.section-ui
+				+textarea('message', 'Введите текст', 'Сообщение')


### PR DESCRIPTION
Получается если я добавляю textarea без заголовка у меня появляется лишний отступ.

mixin textarea(label, text)
.mb-15
.title-medium.pb-15 #{label}
textarea( class = 'textarea pl-15 pt-15 pr-15 pb-30' name='message') #{text}